### PR TITLE
Fix outdated citation and installation instructions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "YamDB"
 uuid = "3738f2fa-2244-4e2d-ac48-d4c5041abf79"
 license = "MIT"
 authors = ["Hiroharu Sugawara <hsugawa@gmail.com>"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ YamDB.jl provides thermophysical property data for liquid metals, molten salts, 
 
 ```julia
 using Pkg
-Pkg.add(url="https://github.com/hsugawa8651/YamDB.jl")
+Pkg.add("YamDB")
 ```
 
 ## Quick Start

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -14,7 +14,7 @@ Julia port of [yamdb](https://codebase.helmholtz.cloud/prosa/yamdb) — Yet Anot
 
 ```julia
 using Pkg
-Pkg.add(url="https://github.com/hsugawa8651/YamDB.jl")
+Pkg.add("YamDB")
 ```
 
 ## Quick Example
@@ -37,7 +37,17 @@ If you use YamDB.jl in your research, please cite both:
 > Sugawara, H. (2026). YamDB.jl: Julia port of yamdb for thermophysical properties of liquid metals and molten salts (Version 0.1.0) [Computer software].
 
 **Original yamdb:**
-> Weier, T., Sarma, M. (2023). yamdb — Yet Another (Molten) Materials Database. *Journal of Open Research Software*, 11(1), p.10. [doi:10.5334/jors.493](https://doi.org/10.5334/jors.493)
+> Weier, T., Nash, W., Personnettaz, P., Weber, N. (2025). Yamdb: easily accessible thermophysical properties of liquid metals and molten salts. *Journal of Open Research Software*, 13(1), 16. [doi:10.5334/jors.493](https://doi.org/10.5334/jors.493)
+
+**Data sources:** In addition, please cite the original sources of the data/equations for the material properties you use. References are available in `references.yml` shipped with YamDB.jl. You can look up references programmatically:
+
+```julia
+# Get the reference for a specific property source
+get_reference(na, "density", "Sobolev2011")
+
+# Look up by citation key
+get_from_references("Sobolev2011")
+```
 
 ## License
 


### PR DESCRIPTION
## Summary

- Fix citation author list to Weier, Nash, Personnettaz, Weber (2025)
- Add `get_reference()` usage example for citing original data sources
- Update installation instructions from `Pkg.add(url="...")` to `Pkg.add("YamDB")` after registry registration
- Bump version to 0.1.1

Closes #3