### PR TITLE
Bump julia-actions/setup-julia v2 -> v3 for Node 24 compatibility

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,7 +20,7 @@ jobs:
           - ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
       - uses: julia-actions/cache@v3
@@ -34,7 +34,7 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@v3
         with:
           version: "1"
       - uses: julia-actions/cache@v3


### PR DESCRIPTION
Bump julia-actions/setup-julia from v2 to v3 (test and docs jobs) for Node 24 compatibility.

Node.js 20 actions are deprecated on GitHub Actions runners
(default switch 2026-06-02, removal 2026-09-16).
actions/checkout and julia-actions/cache are already current.